### PR TITLE
Realign with current CMSSW master branch

### DIFF
--- a/mkfit-geom-cms-2017/CMS-2017.cc
+++ b/mkfit-geom-cms-2017/CMS-2017.cc
@@ -205,7 +205,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 1)  // for triplet steps, nlayers_per_seed=3
@@ -216,7 +216,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 2) {
@@ -226,7 +226,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 3)  // for triplet steps, nlayers_per_seed=3
@@ -237,7 +237,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 4) {
@@ -247,7 +247,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 5)  // for triplet steps, nlayers_per_seed=3
@@ -258,7 +258,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 6)  // for triplet steps, nlayers_per_seed=3; for mixeTripletSetp, also maxCandsPerSeed=2
@@ -269,7 +269,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 7)  // for PixelLess step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
@@ -280,7 +280,7 @@ namespace {
       ip.maxConsecHoles = 1;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 8)  // for TobTec step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
@@ -291,7 +291,7 @@ namespace {
       ip.maxConsecHoles = 1;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     } else if (it == 9)  // addign also pixel pair step - algo -> 6
@@ -302,7 +302,7 @@ namespace {
       ip.maxConsecHoles = 2;
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
-      ip.pTCutOverlap = 1;
+      ip.pTCutOverlap = 0.0;
       ip.minPtCut = 0.0;
       ip.maxClusterSize = 8;
     }

--- a/mkfit-geom-cms-2017/CMS-2017.cc
+++ b/mkfit-geom-cms-2017/CMS-2017.cc
@@ -206,7 +206,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.2;
+      ip.minPtCut = 0.0;
     } else if (it == 1)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -216,7 +216,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.2;
+      ip.minPtCut = 0.0;
     } else if (it == 2) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -225,7 +225,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.075;
+      ip.minPtCut = 0.0;
     } else if (it == 3)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -235,7 +235,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.075;
+      ip.minPtCut = 0.0;
     } else if (it == 4) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -244,7 +244,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.075;
+      ip.minPtCut = 0.0;
     } else if (it == 5)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -254,7 +254,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.075;
+      ip.minPtCut = 0.0;
     } else if (it == 6)  // for triplet steps, nlayers_per_seed=3; for mixeTripletSetp, also maxCandsPerSeed=2
     {
       ip.nlayers_per_seed = 3;
@@ -264,7 +264,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.1;
+      ip.minPtCut = 0.0;
     } else if (it == 7)  // for PixelLess step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -274,7 +274,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.1;
+      ip.minPtCut = 0.0;
     } else if (it == 8)  // for TobTec step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -284,7 +284,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.1;
+      ip.minPtCut = 0.0;
     } else if (it == 9)  // addign also pixel pair step - algo -> 6
     {
       ip.nlayers_per_seed = 2;
@@ -294,7 +294,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
-      ip.minPtCut = 0.1;
+      ip.minPtCut = 0.0;
     }
   }
 

--- a/mkfit-geom-cms-2017/CMS-2017.cc
+++ b/mkfit-geom-cms-2017/CMS-2017.cc
@@ -206,6 +206,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.2;
     } else if (it == 1)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -215,6 +216,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.2;
     } else if (it == 2) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -223,6 +225,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.075;
     } else if (it == 3)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -232,6 +235,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.075;
     } else if (it == 4) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -240,6 +244,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.075;
     } else if (it == 5)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -249,6 +254,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.075;
     } else if (it == 6)  // for triplet steps, nlayers_per_seed=3; for mixeTripletSetp, also maxCandsPerSeed=2
     {
       ip.nlayers_per_seed = 3;
@@ -258,6 +264,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.1;
     } else if (it == 7)  // for PixelLess step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -267,6 +274,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.1;
     } else if (it == 8)  // for TobTec step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -276,6 +284,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.1;
     } else if (it == 9)  // addign also pixel pair step - algo -> 6
     {
       ip.nlayers_per_seed = 2;
@@ -285,6 +294,7 @@ namespace {
       ip.chi2Cut_min = 15.0;
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
+      ip.minPtCut = 0.1;
     }
   }
 

--- a/mkfit-geom-cms-2017/CMS-2017.cc
+++ b/mkfit-geom-cms-2017/CMS-2017.cc
@@ -207,6 +207,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 1)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -217,6 +218,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 2) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -226,6 +228,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 3)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -236,6 +239,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 4) {
       ip.nlayers_per_seed = 4;
       ip.maxCandsPerSeed = 5;
@@ -245,6 +249,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 5)  // for triplet steps, nlayers_per_seed=3
     {
       ip.nlayers_per_seed = 3;
@@ -255,6 +260,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 6)  // for triplet steps, nlayers_per_seed=3; for mixeTripletSetp, also maxCandsPerSeed=2
     {
       ip.nlayers_per_seed = 3;
@@ -265,6 +271,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 7)  // for PixelLess step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -275,6 +282,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 8)  // for TobTec step, maxCandsPerSeed=2 and maxHolesPerCand=maxConsecHoles=0
     {
       ip.nlayers_per_seed = 3;
@@ -285,6 +293,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     } else if (it == 9)  // addign also pixel pair step - algo -> 6
     {
       ip.nlayers_per_seed = 2;
@@ -295,6 +304,7 @@ namespace {
       ip.chi2CutOverlap = 3.5;
       ip.pTCutOverlap = 1;
       ip.minPtCut = 0.0;
+      ip.maxClusterSize = 8;
     }
   }
 


### PR DESCRIPTION
This PR supersedes previous ones and it fully realigns mkFit-external with CMSSW master branch:
- sets `pTCutOverlap` to zero for all iterations;
- introduces/sets `minPtCut` to zero;
- introduces/sets `maxClusterSize` to 8.
These changes correspond to those introduced by PRs cms-sw/cmssw#37580, cms-sw/cmssw#37581, cms-sw/cmssw#37635.